### PR TITLE
UX improvement: add double click support to select an item

### DIFF
--- a/src/components/Item/Card.tsx
+++ b/src/components/Item/Card.tsx
@@ -72,6 +72,7 @@ const CardItem = (props: Props) => {
       display="flex"
       justifyContent="center"
       onClick={handleAssetPick}
+      onDoubleClick={handleSelect}
       p={2}
       position="relative"
       style={style}


### PR DESCRIPTION
Hi!

This PR adds support for the double click event to select a media: now user can just double click to select a media instead of having to single click + click on the "Select" button.

Thanks!