### PR TITLE
UX improvement: set the select/delete buttons in the right logical order

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -37,22 +37,19 @@ const Footer = () => {
     >
       {/* LHS */}
       <Box alignItems="center" display="flex" flex="3 0" height="headerHeight.1" order={[2, 0]}>
-        {onSelect && singlePickedAsset && (
+        {picked.length > 0 && (
           <ButtonGroup>
             <Button
               bleed={true}
+              color="danger"
               kind="simple"
-              onClick={() => {
-                onSelect([
-                  {
-                    kind: 'assetDocumentId',
-                    value: singlePickedAsset._id
-                  }
-                ])
-              }}
+              onClick={onDeletePicked}
               ripple={false}
+              style={{
+                borderRadius: 0
+              }}
             >
-              <strong>Select</strong>
+              <strong>Delete{picked.length > 1 ? ` ${picked.length} images` : ''}</strong>
             </Button>
           </ButtonGroup>
         )}
@@ -161,25 +158,28 @@ const Footer = () => {
       {/* RHS */}
       <Box
         alignItems="center"
+        justifyContent="flex-end"
         display="flex"
         flex="3 0"
         height="headerHeight.1"
-        justifyContent="flex-end"
         order={[2, 2]}
       >
-        {picked.length > 0 && (
+        {onSelect && singlePickedAsset && (
           <ButtonGroup>
             <Button
               bleed={true}
-              color="danger"
               kind="simple"
-              onClick={onDeletePicked}
-              ripple={false}
-              style={{
-                borderRadius: 0
+              onClick={() => {
+                onSelect([
+                  {
+                    kind: 'assetDocumentId',
+                    value: singlePickedAsset._id
+                  }
+                ])
               }}
+              ripple={false}
             >
-              <strong>Delete{picked.length > 1 ? ` ${picked.length} images` : ''}</strong>
+              <strong>Select</strong>
             </Button>
           </ButtonGroup>
         )}


### PR DESCRIPTION
Hi!

This PR inverts the order of the select/delete buttons.
I think this one can be debated on!
I'm not a user experience designer but it felt really weird to have the "select/validation" button on the bottom left I instinctively tried to find it on the right and I thought it was awkward finding it the other way around.
Obviously it might as well just be me so it would be great to have other users input on this! :)

Here are a few screenshot of dialogs:

Sanity "cancel/delete" for a document: here the "validation" button is on the right:
![Screenshot 2020-07-06 at 11 34 45](https://user-images.githubusercontent.com/527559/86607926-44d8cf00-bf80-11ea-905f-fae38e3b8aa8.jpg)

Mac OS cancel/validation, same thing, validation is on the right:
![Screenshot 2020-07-06 at 11 34 31](https://user-images.githubusercontent.com/527559/86608055-6cc83280-bf80-11ea-8cf6-bd8dd396cc2d.jpg)

Android (and pretty much always on mobile "validation" button are on bottom right since it's closer to the thumb):
![Screenshot 2020-07-06 at 12 05 52](https://user-images.githubusercontent.com/527559/86608534-10194780-bf81-11ea-89d4-ebf31098a61b.jpg)




