### PR TITLE
feat: add “Copy URL” button to asset metadata actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@sanity/icons": "1.0.2",
     "@sanity/ui": ">=0.33.11",
     "@tanem/react-nprogress": "3.0.52",
+    "copy-to-clipboard": "^3.3.1",
     "date-fns": "2.16.1",
     "filesize": "6.1.0",
     "framer-motion": "3.6.1",

--- a/src/components/AssetMetadata/index.tsx
+++ b/src/components/AssetMetadata/index.tsx
@@ -1,9 +1,10 @@
-import {DownloadIcon} from '@sanity/icons'
+import {DownloadIcon, ClipboardIcon} from '@sanity/icons'
 import {Box, Button, Flex, Stack, Text} from '@sanity/ui'
 import {Asset, AssetItem} from '@types'
 import format from 'date-fns/format'
 import filesize from 'filesize'
 import React, {FC, ReactNode} from 'react'
+import copy from 'copy-to-clipboard'
 
 import getAssetResolution from '../../utils/getAssetResolution'
 import {isImageAsset} from '../../utils/typeGuards'
@@ -50,6 +51,9 @@ const AssetMetadata: FC<Props> = (props: Props) => {
   const handleDownload = () => {
     window.location.href = `${asset.url}?dl=${asset.originalFilename}`
   }
+  const handleCopy = () => {
+    copy(asset.url)
+  }
 
   return (
     <Box marginTop={3}>
@@ -90,7 +94,7 @@ const AssetMetadata: FC<Props> = (props: Props) => {
         </>
       )}
 
-      {/* Download button */}
+      {/* Asset actions */}
       <Box marginTop={5}>
         <Button
           disabled={!item || item?.updating}
@@ -99,6 +103,15 @@ const AssetMetadata: FC<Props> = (props: Props) => {
           mode="ghost"
           onClick={handleDownload}
           text="Download"
+        />
+
+        <Button
+          disabled={!item || item?.updating}
+          fontSize={1}
+          icon={ClipboardIcon}
+          mode="ghost"
+          onClick={handleCopy}
+          text="Copy URL"
         />
       </Box>
     </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,7 +2102,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3.2.0:
+copy-to-clipboard@^3.2.0, copy-to-clipboard@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==


### PR DESCRIPTION
This adds a “Copy URL” button adjacent to the “Download” button under the asset metadata. I need this for a few clients that upload content to reference externally.

<img width="644" alt="Screen Shot 2021-04-26 at 8 08 53 PM" src="https://user-images.githubusercontent.com/81224/116169880-48824180-a6cb-11eb-924c-f51859c00118.png">

Note: `copy-to-clipboard` is a sub-dependency of the Sanity Studio already.

> info Reasons this module exists
>   - "@tanem#react-nprogress#react-use" depends on it
>   - Hoisted from "@tanem#react-nprogress#react-use#copy-to-clipboard"