### PR TITLE
chore: update @reduxjs/toolkit to 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "2.0.0-beta.3",
-    "@reduxjs/toolkit": "1.5.1",
+    "@reduxjs/toolkit": "1.6.2",
     "@sanity/color": "2.1.5",
     "@sanity/icons": "1.1.7",
     "@sanity/types": "^2.17.1",

--- a/src/components/ReduxProvider/index.tsx
+++ b/src/components/ReduxProvider/index.tsx
@@ -1,4 +1,4 @@
-import {AnyAction, configureStore, getDefaultMiddleware, Store} from '@reduxjs/toolkit'
+import {AnyAction, configureStore, Store} from '@reduxjs/toolkit'
 import {AssetSourceComponentProps} from '@types'
 import React, {Component, ReactNode} from 'react'
 import {Provider} from 'react-redux'
@@ -23,9 +23,8 @@ class ReduxProvider extends Component<Props> {
     const epicMiddleware = createEpicMiddleware<AnyAction, AnyAction, RootReducerState>()
     this.store = configureStore({
       reducer: rootReducer,
-      middleware: [
-        epicMiddleware,
-        ...getDefaultMiddleware({
+      middleware: getDefaultMiddleware =>
+        getDefaultMiddleware({
           /*
           serializableCheck: {
             ignoredActions: [
@@ -38,8 +37,7 @@ class ReduxProvider extends Component<Props> {
           // TODO: remove once we're no longer storing non-serializable data in the store
           serializableCheck: false,
           thunk: false
-        })
-      ],
+        }).prepend(epicMiddleware),
       devTools: true,
       preloadedState: {
         assets: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -519,13 +526,13 @@
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
 
-"@reduxjs/toolkit@1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.5.1.tgz#05daa2f6eebc70dc18cd98a90421fab7fa565dc5"
-  integrity sha512-PngZKuwVZsd+mimnmhiOQzoD0FiMjqVks6ituO1//Ft5UEX5Ca9of13NEjo//pU22Jk7z/mdXVsmDfgsig1osA==
+"@reduxjs/toolkit@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.2.tgz#2f2b5365df77dd6697da28fdf44f33501ed9ba37"
+  integrity sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==
   dependencies:
-    immer "^8.0.1"
-    redux "^4.0.0"
+    immer "^9.0.6"
+    redux "^4.1.0"
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
 
@@ -3491,10 +3498,10 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@^8.0.1:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.4.tgz#3a21605a4e2dded852fb2afd208ad50969737b7a"
-  integrity sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==
+immer@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -5361,6 +5368,13 @@ redux@4.0.5, redux@^4.0.0:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.1.tgz#76f1c439bb42043f985fbd9bf21990e60bd67f47"
+  integrity sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 refractor@^3.3.0:
   version "3.3.1"


### PR DESCRIPTION
## Summary

This PR updates `@reduxjs/toolkit` to 1.6.x. The 1.5.x releases contain a very old version of `immer` (5.x.x) that is showing up in `yarn audit` runs.

I've only done the bare necessities in terms of refactoring to support a small change in the API of `@reduxjs/toolkit`.

`@reduxjs/toolkit@1.6.x` introduces RTK Query, which _might_ be interesting for this package, I'm not sure, maybe something to look into?

This change should be probably be tested.