### PR TITLE
feat: add asset source information & filters

### DIFF
--- a/src/components/AssetMetadata/index.tsx
+++ b/src/components/AssetMetadata/index.tsx
@@ -46,6 +46,7 @@ const AssetMetadata: FC<Props> = (props: Props) => {
   const {asset, item} = props
 
   const exif = asset?.metadata?.exif
+  const source = asset?.source
 
   // Callbacks
   const handleDownload = () => {
@@ -86,6 +87,25 @@ const AssetMetadata: FC<Props> = (props: Props) => {
               {exif.DateTimeOriginal && (
                 <Row label="Original date" value={format(new Date(exif.DateTimeOriginal), 'PPp')} />
               )}
+            </Stack>
+          </Box>
+        </>
+      )}
+      {source && (
+        <>
+          {/* Divider */}
+          <Box
+            marginY={4}
+            style={{
+              background: '#222',
+              height: '1px',
+              width: '100%'
+            }}
+          />
+          <Box>
+            <Stack space={3}>
+              <Row label="Source name" value={source?.name} />
+              <Row label="Source ID" value={source?.id} />
             </Stack>
           </Box>
         </>

--- a/src/config/searchFacets.ts
+++ b/src/config/searchFacets.ts
@@ -240,6 +240,26 @@ export const inputs: Record<SearchFacetName, SearchFacetInputProps> = {
     title: 'Width',
     type: 'number',
     value: 400
+  },
+  sourceName: {
+    assetTypes: ['file', 'image'],
+    field: 'source.name',
+    name: 'sourceName',
+    operatorType: 'includes',
+    operatorTypes: ['empty', 'notEmpty', null, 'includes', 'doesNotInclude'],
+    title: 'Source name',
+    type: 'string',
+    value: ''
+  },
+  sourceID: {
+    assetTypes: ['file', 'image'],
+    field: 'source.id',
+    name: 'sourceID',
+    operatorType: 'includes',
+    operatorTypes: ['empty', 'notEmpty', null, 'includes', 'doesNotInclude'],
+    title: 'Source ID',
+    type: 'string',
+    value: ''
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,9 @@ export const FACETS: (SearchFacetDivider | SearchFacetGroup | SearchFacetInputPr
   inputs.size,
   inputs.type,
   divider,
+  inputs.sourceName,
+  inputs.sourceID,
+  divider,
   inputs.orientation,
   inputs.width,
   inputs.height

--- a/src/modules/assets/index.ts
+++ b/src/modules/assets/index.ts
@@ -218,7 +218,8 @@ const assetsSlice = createSlice({
               originalFilename,
               size,
               title,
-              url
+              url,
+              source
             } ${pipe} ${sort} ${selector},
           }
         `

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -243,6 +243,8 @@ export type SearchFacetName =
   | 'title'
   | 'type'
   | 'width'
+  | 'sourceName'
+  | 'sourceID'
 
 export type SearchFacetOperatorType =
   | 'doesNotInclude'


### PR DESCRIPTION
This adds the asset source name and ID to the asset detail dialog and allows for filtering on those fields.

Our editors use a digital asset management system for company wide asset management, for which we have made a custom asset source in order to import assets into Sanity. This feature allows them to more easily find and keep track of imported assets between the Sanity and company DAM; which is useful for when they for example have to remove a specific asset for GDPR reasons or find out where a specific asset has been used.